### PR TITLE
Add custom HTTP response header "Custom"

### DIFF
--- a/SensitiveWords.API/V1/Controllers/WordsAPIController.cs
+++ b/SensitiveWords.API/V1/Controllers/WordsAPIController.cs
@@ -99,6 +99,8 @@ namespace SensitiveWords.API.V1.Controllers
                         c.Response.Headers["X-TotalPages"] = p.TotalPages.ToString();
                         c.Response.Headers["X-HasNext"] = p.HasNext.ToString().ToLowerInvariant();
                         c.Response.Headers["X-HasPrev"] = p.HasPrevious.ToString().ToLowerInvariant();
+
+                        c.Response.Headers["Custom"] = "We can header what we want!";
                         // If these headers must be readable by browsers, expose them via CORS:
                         // Response.Headers["Access-Control-Expose-Headers"] = "X-Page,X-PageSize,X-TotalCount,X-TotalPages,X-HasNext,X-HasPrev";
                     }


### PR DESCRIPTION
Added a new HTTP response header named `Custom` with the value "We can header what we want!" in the `WordsAPIController.cs` file within the `SensitiveWords.API.V1.Controllers` namespace. This header is included alongside existing pagination-related headers to provide additional metadata in the response.