### PR TITLE
Add "blooping" feature for masking sensitive words

### DIFF
--- a/SensitiveWords.API/SensitiveWords.API.csproj
+++ b/SensitiveWords.API/SensitiveWords.API.csproj
@@ -6,15 +6,11 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>6415786c-2cc8-4446-a94d-7cd420b3917b</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		
-		<!-- Generate XML docs -->
+
+		<!-- Enable XML docs so Swagger can read your <summary>, <remarks>, param docs, etc. -->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-
-		<!-- Optional: silence missing XML warnings while you wire things up -->
 		<NoWarn>$(NoWarn);1591</NoWarn>
-
-		<!-- Optional: make the filename explicit (helps when you have multiple projects) -->
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SensitiveWords.API.xml</DocumentationFile>
+		<!-- ignore "missing XML doc" warnings -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SensitiveWords.API/V1/Controllers/BloopAPIController.cs
+++ b/SensitiveWords.API/V1/Controllers/BloopAPIController.cs
@@ -3,27 +3,87 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using SensitiveWords.Application.Abstractions.Services;
 using SensitiveWords.Application.Attributes;
+using SensitiveWords.Application.Common.Responses;
 using SensitiveWords.Domain.Dtos;
 
 namespace SensitiveWords.API.Controllers
 {
-    // External endpoint to star out sensitive words/phrases in a message
+    /// <summary>
+    /// EXTERNAL API — Message “blooping” (masking) endpoint.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Public-facing endpoint to scan a message and mask sensitive words/phrases. This route is intended
+    /// for first-party clients (web/app/services). It returns a <see cref="BloopResponseDto"/> directly
+    /// (no envelope), to keep the contract small and simple for external callers.
+    /// </para>
+    /// <para>
+    /// 🔐 <b>Security:</b> Protect this route with your API gateway and authentication (e.g., JWT/OIDC)
+    /// before exposing publicly. Apply rate-limiting (configured via <c>BloopPerHour</c> policy) to deter abuse.
+    /// </para>
+    /// <para>
+    /// 🧠 <b>Matching mode:</b> The request’s <c>WholeWord</c> flag controls boundary handling. When true,
+    /// the underlying regex uses word edges where appropriate; when false, matches substrings anywhere.
+    /// </para>
+    /// <para>
+    /// 📄 <b>Example request</b>:
+    /// <code>
+    /// POST /api/v1.0/messages/bloop
+    /// {
+    ///   "message": "Please don't DROP TABLE users;",
+    ///   "wholeWord": true
+    /// }
+    /// </code>
+    /// <b>Example response</b>:
+    /// <code>
+    /// {
+    ///   "original": "Please don't DROP TABLE users;",
+    ///   "blooped":  "Please don't **** ***** users;",
+    ///   "matches":  2,
+    ///   "elapsedMs": 3
+    /// }
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Notes:
+    /// <list type="bullet">
+    ///   <item><description>Validation errors (e.g., missing <c>message</c>) return <c>400</c> with your standard error body.</description></item>
+    ///   <item><description>When rate limit is exceeded, returns <c>429</c> (per <c>BloopPerHour</c> policy).</description></item>
+    ///   <item><description>Server faults return <c>500</c> with a trace id.</description></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
     [ApiController]
-    [ApiVersion(1.0)]
+    [ApiVersion("1.0")]
     [Route("api/v{version:apiVersion}/messages")]
     [Audience(AudienceAttribute.External)]
     [Produces("application/json")]
     [Tags("Bloop")]
     public class BloopAPIController : ControllerBase
     {
+        private readonly IBloopService _svc;
+        public BloopAPIController(IBloopService svc) => _svc = svc;
 
-
-        /// <summary>Stars out sensitive words/phrases in a message.</summary>
+        /// <summary>
+        /// Stars-out (masks) sensitive words/phrases in a message.
+        /// </summary>
+        /// <remarks>
+        /// Uses a compiled, cached regex sourced from the internal words repository. Each match is replaced by
+        /// a string of asterisks of equal length. If you need a different masking policy, change it in <c>BloopService</c>.
+        /// </remarks>
+        /// <param name="req">Message to scan and the matching mode (whole-word vs substring).</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <response code="200">Masked result with match count and elapsed processing time.</response>
+        /// <response code="400">Validation failure (e.g., missing or empty <c>message</c>).</response>
+        /// <response code="429">Too many requests (rate limit exceeded).</response>
+        /// <response code="500">Unexpected server error.</response>
         [HttpPost("bloop")]
-        public IActionResult Bloop()
-        {
-            throw new NotImplementedException();
-        }
-       
+        [EnableRateLimiting("BloopPerHour")] // configure in Program.cs: one token bucket per client identity
+        [ProducesResponseType(typeof(BloopResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Bloop([FromBody] BloopRequestDto req, CancellationToken ct = default)
+            => Ok(await _svc.BloopAsync(req, ct));
     }
 }

--- a/SensitiveWords.Application/Abstractions/Services/IBloopService.cs
+++ b/SensitiveWords.Application/Abstractions/Services/IBloopService.cs
@@ -1,0 +1,45 @@
+﻿using SensitiveWords.Domain.Dtos;
+
+namespace SensitiveWords.Application.Abstractions.Services
+{
+    /// <summary>
+    /// Service contract for masking ("blooping") sensitive words in a message.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implementations typically obtain a compiled, versioned regex from <c>IWordsCache</c>,
+    /// apply it to the input message, and return a response containing the original text,
+    /// the masked result, the total match count, and elapsed processing time.
+    /// </para>
+    /// <para>
+    /// Thread-safety: Implementations should be stateless and safe to use across requests.
+    /// Regex compilation/caching concerns belong in <c>IWordsCache</c>.
+    /// </para>
+    /// </remarks>
+    public interface IBloopService
+    {
+        /// <summary>
+        /// Masks all sensitive-word matches in the given request and returns details of the operation.
+        /// </summary>
+        /// <param name="request">
+        /// Input containing the <c>Message</c> to scan and the matching mode
+        /// (<c>WholeWord</c> controls boundary behavior in the underlying regex).
+        /// </param>
+        /// <param name="ct">
+        /// Cancellation token (observed while retrieving/constructing the regex; the replace operation
+        /// itself is typically synchronous and may not observe cancellation).
+        /// </param>
+        /// <returns>
+        /// A <see cref="BloopResponseDto"/> containing the original text, the masked text,
+        /// the number of matches found, and the server-side elapsed time in milliseconds.
+        /// </returns>
+        /// <remarks>
+        /// <list type="bullet">
+        ///   <item><description>May throw <see cref="OperationCanceledException"/> if <paramref name="ct"/> is canceled.</description></item>
+        ///   <item><description>Implementations should treat <c>request.Message</c> as required (validate in the API layer).</description></item>
+        ///   <item><description>Matching semantics (whole word vs substring, whitespace handling, etc.) are dictated by the regex supplied by <c>IWordsCache</c>.</description></item>
+        /// </list>
+        /// </remarks>
+        Task<BloopResponseDto> BloopAsync(BloopRequestDto request, CancellationToken ct);
+    }
+}

--- a/SensitiveWords.Application/Services/BloopService.cs
+++ b/SensitiveWords.Application/Services/BloopService.cs
@@ -1,0 +1,85 @@
+﻿using SensitiveWords.Application.Abstractions.Caching;
+using SensitiveWords.Application.Abstractions.Services;
+using SensitiveWords.Domain.Dtos;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace SensitiveWords.Application.Services
+{
+    /// <summary>
+    /// Applies the sensitive-word regex to a message and returns a masked ("blooped") result.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The regex comes from <see cref="IWordsCache"/> which compiles it (case-insensitive,
+    /// culture-invariant) and versions it via metadata so callers don’t rebuild patterns unnecessarily.
+    /// </para>
+    /// <para>
+    /// Masking strategy: each match is replaced with a string of <c>'*'</c> characters
+    /// equal to the match length (simple, reversible-proof, preserves layout).
+    /// If you need a different policy (fixed length, partial masking, custom char),
+    /// consider introducing options (e.g., <c>BloopOptions</c>).
+    /// </para>
+    /// <para>
+    /// Performance note: <see cref="Regex.Replace(string, MatchEvaluator)"/> executes synchronously.
+    /// We only await the regex retrieval. <see cref="ElapsedMs"/> measures server-side work here
+    /// (cache fetch + replace), not network latency.
+    /// </para>
+    /// <para>
+    /// Cancellation: honored while fetching the regex; the replace itself is not cancelable.
+    /// If you need mid-replace cancellation for very large inputs, you’d need chunked processing.
+    /// </para>
+    /// </remarks>
+    public class BloopService : IBloopService
+    {
+        private readonly IWordsCache _cache;
+
+        public BloopService(IWordsCache cache)
+        {
+            _cache = cache;
+        }
+
+        /// <summary>
+        /// Masks all sensitive-word matches in <paramref name="request"/> using the compiled regex
+        /// and returns the original text, masked text, match count, and elapsed time (ms).
+        /// </summary>
+        /// <param name="request">
+        /// Input message and matching mode (<see cref="BloopRequestDto.WholeWord"/> decides whether
+        /// word boundaries are enforced by the regex).
+        /// </param>
+        /// <param name="ct">Cancellation token (applies to regex retrieval only).</param>
+        /// <returns>A <see cref="BloopResponseDto"/> with the original, blooped text, match count, and runtime.</returns>
+        /// <remarks>
+        /// Assumptions:
+        /// <list type="bullet">
+        ///   <item><description><c>request.Message</c> is non-null (controller/model validation should enforce).</description></item>
+        ///   <item><description>Regex is pre-escaped/constructed safely by <see cref="IWordsCache"/>.</description></item>
+        ///   <item><description>Match count increments once per regex match (no overlap counting).</description></item>
+        /// </list>
+        /// </remarks>
+        public async Task<BloopResponseDto> BloopAsync(BloopRequestDto request, CancellationToken ct)
+        {
+            var sw = Stopwatch.StartNew();
+
+            // Get (or build) the compiled regex for current version and whole-word mode.
+            var regex = await _cache.GetRegexAsync(request.WholeWord, ct);
+
+            // Replace with same-length asterisks and count matches.
+            int matches = 0;
+            string Evaluator(Match m)
+            {
+                matches++;
+                return new string('*', m.Length);
+            }
+
+            var blooped = regex.Replace(request.Message, new MatchEvaluator(Evaluator));
+
+            sw.Stop();
+            return new BloopResponseDto(
+                original: request.Message,
+                blooped: blooped,
+                matches: matches,
+                elapsedMs: sw.ElapsedMilliseconds);
+        }
+    }
+}

--- a/SensitiveWords.Domain/Dtos/BloopRequestDto.cs
+++ b/SensitiveWords.Domain/Dtos/BloopRequestDto.cs
@@ -1,0 +1,58 @@
+﻿namespace SensitiveWords.Domain.Dtos
+{
+    /// <summary>
+    /// Request payload used when checking a text message against the sensitive-words list.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Message</b> is the raw text to scan. <b>WholeWord</b> controls how the regex is built:
+    /// when true, the service will prefer word-boundary matches (e.g., matches <c>"drop"</c> as a word,
+    /// but not inside <c>"backdrop"</c>); when false, it will match anywhere in the string.
+    /// </para>
+    /// <para>
+    /// Internally this typically flows into <c>IWordsCache.GetRegexAsync(WholeWord)</c>, then the compiled
+    /// regex is applied to <c>Message</c>.
+    /// </para>
+    /// <para>
+    /// <b>Example</b>:
+    /// <code>
+    /// {
+    ///   "message": "Please don't DROP TABLE users;",
+    ///   "wholeWord": true
+    /// }
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Tip: If you want model-validation (400 on missing/empty message), add
+    /// <c>[Required]</c> / <c>[StringLength]</c> attributes to <see cref="Message"/> in the future.
+    /// We avoided adding them here to keep current behavior unchanged.
+    /// </para>
+    /// </remarks>
+    public class BloopRequestDto
+    {
+        /// <summary>
+        /// Creates a new request with the text to scan and the matching mode.
+        /// </summary>
+        /// <param name="message">The raw text to check against the sensitive-words regex.</param>
+        /// <param name="wholeWord">
+        /// If true, prefer whole-word/phrase matches (word boundaries where appropriate);
+        /// if false, allow substring matches. Defaults to true.
+        /// </param>
+        public BloopRequestDto(string message, bool wholeWord)
+        {
+            Message = message;
+            WholeWord = wholeWord;
+        }
+
+        /// <summary>
+        /// The input text to be scanned for sensitive words.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// When true, applies word boundaries where sensible (whole-word match);
+        /// when false, matches anywhere within the text. Defaults to true.
+        /// </summary>
+        public bool WholeWord { get; set; } = true;
+    }
+}

--- a/SensitiveWords.Domain/Dtos/BloopResponseDto.cs
+++ b/SensitiveWords.Domain/Dtos/BloopResponseDto.cs
@@ -1,0 +1,81 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SensitiveWords.Domain.Dtos
+{
+    /// <summary>
+    /// Response returned after scanning and masking a message ("blooping").
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Original</b> is the exact input text received. <b>Blooped</b> is the output after
+    /// sensitive terms have been masked or transformed by the service’s policy.
+    /// </para>
+    /// <para>
+    /// <b>Matches</b> is the total number of matches found (and typically masked). Depending on
+    /// the implementation, this may count overlapping matches or phrase matches once—check the
+    /// service’s masking rules if exact semantics matter.
+    /// </para>
+    /// <para>
+    /// <b>ElapsedMs</b> is the server-side processing time in milliseconds for the scan/mask step
+    /// (usually measured with <c>Stopwatch</c>); it excludes network latency and client time.
+    /// Use it as a rough performance indicator, not an SLA.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// <code>
+    /// {
+    ///   "original": "Please don't DROP TABLE users;",
+    ///   "blooped":  "Please don't ████ █████ users;",
+    ///   "matches":  2,
+    ///   "elapsedMs": 3
+    /// }
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Note: If callers later need more detail (e.g., which words were matched or their positions),
+    /// consider adding an optional array (e.g., <c>hits</c>) to this DTO to preserve compatibility.
+    /// </para>
+    /// </remarks>
+    public class BloopResponseDto
+    {
+        /// <summary>
+        /// Creates a new response with the original text, the masked result, the match count,
+        /// and the server-side processing time in milliseconds.
+        /// </summary>
+        /// <param name="original">The exact input text that was scanned.</param>
+        /// <param name="blooped">The output text after masking/transformation.</param>
+        /// <param name="matches">Total number of matches found (and usually masked).</param>
+        /// <param name="elapsedMs">Processing time on the server, in milliseconds.</param>
+        public BloopResponseDto(string original, string blooped, int matches, long elapsedMs)
+        {
+            Original = original;
+            Blooped = blooped;
+            Matches = matches;
+            ElapsedMs = elapsedMs;
+        }
+
+        /// <summary>
+        /// The exact input text that was scanned. Returned for caller convenience/debugging.
+        /// </summary>
+        [JsonPropertyName("original")]
+        public string Original { get; set; }
+
+        /// <summary>
+        /// The masked or transformed text produced by the service.
+        /// </summary>
+        [JsonPropertyName("blooped")]
+        public string Blooped { get; set; }
+
+        /// <summary>
+        /// Total number of matches discovered during the scan (implementation-defined).
+        /// </summary>
+        [JsonPropertyName("matches")]
+        public int Matches { get; set; }
+
+        /// <summary>
+        /// Server-side processing time in milliseconds for the scan/mask operation.
+        /// </summary>
+        [JsonPropertyName("elapsedMs")]
+        public long ElapsedMs { get; set; }
+    }
+}


### PR DESCRIPTION
Introduced a new "blooping" feature to mask sensitive words in text messages. Key changes include:

- Added `BloopService` for regex-based masking with caching.
- Exposed the `Bloop` endpoint in `BloopAPIController` with rate-limiting.
- Registered new services and repositories in DI, including `IWordsCache`, `IBloopService`, and database-related dependencies.
- Enhanced Swagger setup to support internal and external API definitions.
- Enabled XML documentation in `SensitiveWords.API.csproj` for better API docs.
- Added `BloopRequestDto` and `BloopResponseDto` to define input/output contracts.
- Documented all new components with detailed XML comments.

These changes improve API clarity, performance, and extensibility while introducing a secure, public-facing endpoint for masking sensitive words.